### PR TITLE
Add automatic dependency installer for missing Python packages

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,65 +18,95 @@
 
 ## Installation Methods
 
-### Method 1: QGIS Plugin Manager (Recommended - When Published)
+### Method 1: Install from ZIP (Recommended)
+
+This is the easiest method for testing and development.
+
+#### Step 1: Prepare the Plugin ZIP
+
+1. Download or clone the repository
+2. Navigate to the `georefio` folder
+3. Create a ZIP file of ONLY the `magic_georeferencer` folder:
+   - **Windows**: Right-click `magic_georeferencer` folder â†’ "Send to" â†’ "Compressed (zipped) folder"
+   - **macOS**: Right-click `magic_georeferencer` folder â†’ "Compress magic_georeferencer"
+   - **Linux**: `zip -r magic_georeferencer.zip magic_georeferencer/`
+
+#### Step 2: Install in QGIS
 
 1. Open QGIS
-2. Go to `Plugins ’ Manage and Install Plugins`
+2. Go to `Plugins > Manage and Install Plugins`
+3. Click on "Install from ZIP" tab
+4. Click the "..." button and select your `magic_georeferencer.zip` file
+5. Click "Install Plugin"
+
+#### Step 3: Install Dependencies (AUTOMATIC)
+
+When you first click the plugin icon in QGIS:
+
+1. A dialog will appear showing missing Python packages
+2. Click **"Install Dependencies"** button
+3. Wait for installation to complete (may take 5-10 minutes)
+4. **Restart QGIS** when prompted
+5. The plugin is now ready to use!
+
+**What gets installed:**
+- PyTorch and TorchVision (deep learning framework)
+- Transformers and HuggingFace Hub (AI model support)
+- OpenCV (image processing)
+- SciPy and NumPy (scientific computing)
+
+### Method 2: Manual Dependency Installation
+
+If automatic installation doesn't work, you can install dependencies manually:
+
+#### Windows (OSGeo4W Shell)
+
+1. Open **OSGeo4W Shell** from Start Menu (comes with QGIS)
+2. Run the following commands:
+
+```bash
+# Navigate to plugin directory
+cd "C:\Users\YourName\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\magic_georeferencer"
+
+# Install dependencies
+python -m pip install --user -r requirements.txt
+```
+
+Or install packages individually:
+```bash
+python -m pip install --user opencv-python>=4.8.0
+python -m pip install --user torch>=2.0.0 torchvision>=0.15.0
+python -m pip install --user transformers>=4.30.0 huggingface-hub>=0.16.0
+python -m pip install --user scipy>=1.9.0
+```
+
+#### macOS/Linux
+
+1. Open Terminal
+2. Find QGIS Python path:
+```bash
+# Method 1: Check QGIS Python
+which python3
+
+# Method 2: Check in QGIS Python Console
+# Open QGIS > Plugins > Python Console > Type: import sys; print(sys.executable)
+```
+
+3. Install dependencies:
+```bash
+# Replace /path/to/qgis/python3 with actual path
+/path/to/qgis/python3 -m pip install --user -r requirements.txt
+```
+
+### Method 3: QGIS Plugin Manager (When Published)
+
+Once published to the official QGIS plugin repository:
+
+1. Open QGIS
+2. Go to `Plugins > Manage and Install Plugins`
 3. Search for "Magic Georeferencer"
 4. Click "Install Plugin"
-5. Enable the plugin if not automatically enabled
-
-### Method 2: Manual Installation (Development/Testing)
-
-#### Step 1: Locate QGIS Plugins Directory
-
-**Windows:**
-```
-C:\Users\YourName\AppData\Roaming\QGIS\QGIS3\profiles\default\python\plugins\
-```
-
-**macOS:**
-```
-~/Library/Application Support/QGIS/QGIS3/profiles/default/python/plugins/
-```
-
-**Linux:**
-```
-~/.local/share/QGIS/QGIS3/profiles/default/python/plugins/
-```
-
-#### Step 2: Install the Plugin
-
-**Option A: Clone from Git**
-```bash
-cd [QGIS plugins directory]
-git clone https://github.com/yourusername/georefio.git
-cd georefio
-cp -r magic_georeferencer ../
-```
-
-**Option B: Download and Extract**
-1. Download the plugin ZIP file
-2. Extract to the QGIS plugins directory
-3. Ensure the folder is named `magic_georeferencer`
-
-#### Step 3: Install Python Dependencies
-
-The plugin requires additional Python packages. Install them in QGIS's Python environment:
-
-**On Windows (using OSGeo4W Shell):**
-```bash
-python-qgis -m pip install torch torchvision transformers huggingface-hub scipy
-```
-
-**On macOS/Linux:**
-```bash
-# Find QGIS Python
-which python3  # or the python bundled with QGIS
-
-# Install packages
-pip3 install torch torchvision transformers huggingface-hub scipy opencv-python-headless
-```
+5. Dependencies will be automatically installed
 
 **Alternative: Use QGIS Python Console**
 ```python
@@ -98,7 +128,7 @@ for package in packages:
 #### Step 4: Enable the Plugin
 
 1. Restart QGIS
-2. Go to `Plugins ’ Manage and Install Plugins`
+2. Go to `Plugins ï¿½ Manage and Install Plugins`
 3. Click on "Installed" tab
 4. Find "Magic Georeferencer" and check the box to enable it
 
@@ -128,7 +158,7 @@ If no GPU is found:
 
 1. Open QGIS
 2. Look for the Magic Georeferencer icon in the toolbar
-3. Or go to `Raster ’ Magic Georeferencer`
+3. Or go to `Raster ï¿½ Magic Georeferencer`
 
 ### Test the Plugin
 
@@ -145,7 +175,7 @@ If no GPU is found:
 **Solutions:**
 1. Check the plugin directory path is correct
 2. Ensure the folder is named exactly `magic_georeferencer`
-3. Check QGIS error log: `Plugins ’ Python Console ’ Show Errors`
+3. Check QGIS error log: `Plugins ï¿½ Python Console ï¿½ Show Errors`
 4. Verify QGIS version is 3.22 or higher
 
 ### Import Errors
@@ -154,7 +184,7 @@ If no GPU is found:
 
 **Solutions:**
 1. Install dependencies in QGIS Python environment (see Step 3 above)
-2. Check Python path in QGIS: `Settings ’ Options ’ System ’ Environment`
+2. Check Python path in QGIS: `Settings ï¿½ Options ï¿½ System ï¿½ Environment`
 3. Try installing with pip in QGIS Python Console
 
 ### CUDA Not Detected
@@ -201,7 +231,7 @@ If no GPU is found:
 
 ### Using Plugin Manager
 
-1. Go to `Plugins ’ Manage and Install Plugins`
+1. Go to `Plugins ï¿½ Manage and Install Plugins`
 2. Find "Magic Georeferencer"
 3. Click "Uninstall Plugin"
 
@@ -217,7 +247,7 @@ If no GPU is found:
 
 ### Via Plugin Manager (When Published)
 
-1. Go to `Plugins ’ Manage and Install Plugins`
+1. Go to `Plugins ï¿½ Manage and Install Plugins`
 2. Click "Upgradeable" tab
 3. Find "Magic Georeferencer" if an update is available
 4. Click "Upgrade Plugin"
@@ -233,7 +263,7 @@ If no GPU is found:
 
 If you encounter issues:
 
-1. **Check the logs**: `Plugins ’ Python Console` in QGIS
+1. **Check the logs**: `Plugins ï¿½ Python Console` in QGIS
 2. **Read the documentation**: See `USAGE.md` and `README.md`
 3. **Report issues**: https://github.com/yourusername/georefio/issues
 4. **Ask for help**: QGIS community forums or plugin GitHub discussions
@@ -248,7 +278,7 @@ If you encounter issues:
 
 ### macOS
 
-- May need to allow Python to access files in System Preferences ’ Security
+- May need to allow Python to access files in System Preferences ï¿½ Security
 - Use Homebrew Python if QGIS Python has issues
 - M1/M2 Macs: Use CPU mode (PyTorch MPS support coming soon)
 

--- a/magic_georeferencer/dependency_installer.py
+++ b/magic_georeferencer/dependency_installer.py
@@ -1,0 +1,239 @@
+"""
+Dependency installer for Magic Georeferencer plugin.
+
+Handles installation of Python packages required by the plugin into QGIS's Python environment.
+"""
+
+import sys
+import subprocess
+from pathlib import Path
+from typing import List, Tuple
+
+
+class DependencyInstaller:
+    """Manages installation of required Python packages."""
+
+    # Required packages with minimum versions
+    REQUIRED_PACKAGES = [
+        'opencv-python>=4.8.0',
+        'torch>=2.0.0',
+        'torchvision>=0.15.0',
+        'transformers>=4.30.0',
+        'huggingface-hub>=0.16.0',
+        'scipy>=1.9.0',
+    ]
+
+    # Package import names (different from pip names in some cases)
+    IMPORT_NAMES = {
+        'opencv-python': 'cv2',
+        'torch': 'torch',
+        'torchvision': 'torchvision',
+        'transformers': 'transformers',
+        'huggingface-hub': 'huggingface_hub',
+        'scipy': 'scipy',
+    }
+
+    def __init__(self):
+        self.missing_packages = []
+        self.python_exe = sys.executable
+
+    def check_dependencies(self) -> Tuple[bool, List[str]]:
+        """
+        Check if all required dependencies are installed.
+
+        Returns:
+            (all_installed, missing_packages)
+        """
+        self.missing_packages = []
+
+        for package_spec in self.REQUIRED_PACKAGES:
+            # Extract package name (before >= or ==)
+            package_name = package_spec.split('>=')[0].split('==')[0]
+            import_name = self.IMPORT_NAMES.get(package_name, package_name)
+
+            try:
+                __import__(import_name)
+            except ImportError:
+                self.missing_packages.append(package_spec)
+
+        return len(self.missing_packages) == 0, self.missing_packages
+
+    def install_dependencies(self, progress_callback=None) -> Tuple[bool, str]:
+        """
+        Install missing dependencies using pip.
+
+        Args:
+            progress_callback: Optional callback function(message: str)
+
+        Returns:
+            (success, message)
+        """
+        if not self.missing_packages:
+            return True, "All dependencies already installed"
+
+        try:
+            for i, package in enumerate(self.missing_packages, 1):
+                if progress_callback:
+                    progress_callback(f"Installing {package} ({i}/{len(self.missing_packages)})...")
+
+                # Use pip to install the package
+                result = subprocess.run(
+                    [self.python_exe, '-m', 'pip', 'install', '--user', package],
+                    capture_output=True,
+                    text=True,
+                    timeout=300  # 5 minute timeout per package
+                )
+
+                if result.returncode != 0:
+                    error_msg = f"Failed to install {package}:\n{result.stderr}"
+                    return False, error_msg
+
+            if progress_callback:
+                progress_callback("All dependencies installed successfully!")
+
+            return True, "Dependencies installed successfully. Please restart QGIS."
+
+        except subprocess.TimeoutExpired:
+            return False, "Installation timed out. Please check your internet connection."
+        except Exception as e:
+            return False, f"Installation error: {str(e)}"
+
+    def get_installation_instructions(self) -> str:
+        """
+        Get manual installation instructions for missing packages.
+
+        Returns:
+            Formatted instruction string
+        """
+        if not self.missing_packages:
+            return "All dependencies are installed."
+
+        packages_str = ' '.join(self.missing_packages)
+
+        instructions = f"""
+Magic Georeferencer requires additional Python packages.
+
+Missing packages:
+{chr(10).join(f'  - {pkg}' for pkg in self.missing_packages)}
+
+AUTOMATIC INSTALLATION:
+The plugin can install these automatically. Click 'Install Dependencies' when prompted.
+
+MANUAL INSTALLATION:
+If automatic installation fails, you can install manually:
+
+Windows:
+1. Open OSGeo4W Shell (from Start Menu)
+2. Run: python -m pip install --user {packages_str}
+
+macOS/Linux:
+1. Open Terminal
+2. Find QGIS Python: which python3
+3. Run: /path/to/qgis/python3 -m pip install --user {packages_str}
+
+After installation, restart QGIS.
+"""
+        return instructions
+
+
+def check_and_prompt_install(parent_widget=None):
+    """
+    Check dependencies and prompt user to install if needed.
+
+    Args:
+        parent_widget: Parent Qt widget for dialogs (optional)
+
+    Returns:
+        True if all dependencies available, False otherwise
+    """
+    installer = DependencyInstaller()
+    all_installed, missing = installer.check_dependencies()
+
+    if all_installed:
+        return True
+
+    # Try to import Qt for dialog
+    try:
+        from qgis.PyQt.QtWidgets import QMessageBox, QProgressDialog
+        from qgis.PyQt.QtCore import Qt
+
+        # Show missing packages dialog
+        msg = QMessageBox(parent_widget)
+        msg.setIcon(QMessageBox.Warning)
+        msg.setWindowTitle("Magic Georeferencer - Missing Dependencies")
+        msg.setText("Magic Georeferencer requires additional Python packages.")
+        msg.setInformativeText(
+            f"Missing packages:\n" +
+            "\n".join(f"  • {pkg}" for pkg in missing[:5]) +
+            (f"\n  ... and {len(missing)-5} more" if len(missing) > 5 else "")
+        )
+        msg.setDetailedText(installer.get_installation_instructions())
+
+        install_btn = msg.addButton("Install Dependencies", QMessageBox.AcceptRole)
+        manual_btn = msg.addButton("Show Manual Instructions", QMessageBox.HelpRole)
+        cancel_btn = msg.addButton("Cancel", QMessageBox.RejectRole)
+
+        msg.exec_()
+        clicked = msg.clickedButton()
+
+        if clicked == install_btn:
+            # Show progress dialog
+            progress = QProgressDialog(
+                "Installing dependencies...",
+                "Cancel",
+                0,
+                0,  # Indeterminate progress
+                parent_widget
+            )
+            progress.setWindowTitle("Magic Georeferencer")
+            progress.setWindowModality(Qt.WindowModal)
+            progress.show()
+
+            def update_progress(message):
+                progress.setLabelText(message)
+                from qgis.PyQt.QtWidgets import QApplication
+                QApplication.processEvents()
+
+            success, message = installer.install_dependencies(update_progress)
+            progress.close()
+
+            # Show result
+            result_msg = QMessageBox(parent_widget)
+            if success:
+                result_msg.setIcon(QMessageBox.Information)
+                result_msg.setWindowTitle("Installation Complete")
+                result_msg.setText("Dependencies installed successfully!")
+                result_msg.setInformativeText(
+                    "Please restart QGIS for changes to take effect."
+                )
+            else:
+                result_msg.setIcon(QMessageBox.Critical)
+                result_msg.setWindowTitle("Installation Failed")
+                result_msg.setText("Failed to install dependencies.")
+                result_msg.setInformativeText(message)
+                result_msg.setDetailedText(installer.get_installation_instructions())
+
+            result_msg.exec_()
+            return False  # Require restart
+
+        elif clicked == manual_btn:
+            # Show manual instructions
+            info_msg = QMessageBox(parent_widget)
+            info_msg.setIcon(QMessageBox.Information)
+            info_msg.setWindowTitle("Manual Installation Instructions")
+            info_msg.setText("Manual Dependency Installation")
+            info_msg.setDetailedText(installer.get_installation_instructions())
+            info_msg.exec_()
+            return False
+        else:
+            # User cancelled
+            return False
+
+    except ImportError:
+        # Can't show GUI, print to console
+        print("=" * 60)
+        print("Magic Georeferencer - Missing Dependencies")
+        print("=" * 60)
+        print(installer.get_installation_instructions())
+        print("=" * 60)
+        return False

--- a/magic_georeferencer/magic_georeferencer.py
+++ b/magic_georeferencer/magic_georeferencer.py
@@ -129,14 +129,31 @@ class MagicGeoreferencer:
 
     def run(self):
         """Run method that performs all the real work"""
-        # Lazy import to speed up plugin loading
-        from .ui.main_dialog import MagicGeoreferencerDialog
+        # Check dependencies before importing
+        from .dependency_installer import check_and_prompt_install
 
-        # Create the dialog if it doesn't exist
-        if self.dialog is None:
-            self.dialog = MagicGeoreferencerDialog(self.iface)
+        if not check_and_prompt_install(self.iface.mainWindow()):
+            # Dependencies not available or user cancelled
+            return
 
-        # Show the dialog
-        self.dialog.show()
-        # Run the dialog event loop
-        self.dialog.exec_()
+        try:
+            # Lazy import to speed up plugin loading
+            from .ui.main_dialog import MagicGeoreferencerDialog
+
+            # Create the dialog if it doesn't exist
+            if self.dialog is None:
+                self.dialog = MagicGeoreferencerDialog(self.iface)
+
+            # Show the dialog
+            self.dialog.show()
+            # Run the dialog event loop
+            self.dialog.exec_()
+
+        except ImportError as e:
+            # Show error if imports still fail after dependency check
+            QMessageBox.critical(
+                self.iface.mainWindow(),
+                "Magic Georeferencer - Import Error",
+                f"Failed to load plugin components:\n\n{str(e)}\n\n"
+                "Please restart QGIS after installing dependencies."
+            )

--- a/magic_georeferencer/requirements.txt
+++ b/magic_georeferencer/requirements.txt
@@ -1,0 +1,23 @@
+# Magic Georeferencer - Python Dependencies
+# These packages are required for the plugin to function
+
+# Deep Learning Framework
+torch>=2.0.0
+torchvision>=0.15.0
+
+# AI Model Integration
+transformers>=4.30.0
+huggingface-hub>=0.16.0
+
+# Scientific Computing
+scipy>=1.9.0
+numpy>=1.21.0
+
+# Image Processing
+opencv-python>=4.8.0
+pillow>=9.0.0
+
+# Installation:
+# The plugin will automatically prompt to install these packages when first run.
+# For manual installation, use:
+#   python -m pip install --user -r requirements.txt


### PR DESCRIPTION
This commit adds a comprehensive dependency management system that automatically detects and installs required Python packages when the plugin is first run.

New Features:
- dependency_installer.py: Complete dependency checker and installer
  - Detects missing packages (opencv-python, torch, transformers, etc.)
  - Shows user-friendly dialog with install options
  - Automatic installation with progress tracking
  - Manual installation instructions for fallback
  - Proper error handling and timeout management

- Updated magic_georeferencer.py:
  - Check dependencies before importing core modules
  - Prevents ImportError crashes on missing packages
  - Shows clear error messages if installation needed

- requirements.txt: Centralized package requirements list
  - All required packages with minimum versions
  - Easy reference for manual installation

- Updated INSTALL.md:
  - Clear ZIP installation instructions (matches actual workflow)
  - Documented automatic dependency installation (Method 1)
  - Windows OSGeo4W Shell instructions for manual install
  - Step-by-step guide matching user's experience

This fixes the "ModuleNotFoundError: No module named 'cv2'" error by proactively installing dependencies before they're needed.

User Experience:
1. User installs plugin from ZIP
2. User clicks plugin icon
3. Dialog appears: "Install Dependencies" button
4. Click button, wait 5-10 minutes
5. Restart QGIS
6. Plugin ready to use!