### PR TITLE
Fix UTF-8 encoding issues causing SyntaxError

### DIFF
--- a/magic_georeferencer/core/gcp_generator.py
+++ b/magic_georeferencer/core/gcp_generator.py
@@ -61,7 +61,7 @@ class GCPGenerator:
            a. Source coords: pixel coords in ungeoreferenced image
            b. Ref coords: pixel coords in basemap image
            c. Transform ref pixel coords to geographic coords using extent
-           d. Create GCP with source pixels ’ geographic coords
+           d. Create GCP with source pixels -> geographic coords
         """
         if not QGIS_AVAILABLE:
             raise RuntimeError("QGIS is not available")

--- a/magic_georeferencer/ui/main_dialog.py
+++ b/magic_georeferencer/ui/main_dialog.py
@@ -339,7 +339,7 @@ class MagicGeoreferencerDialog(QDialog):
                 from PIL import Image
                 img = Image.open(self.source_image_path)
                 width, height = img.size
-                self.image_info_label.setText(f"Image size: {width} � {height} px")
+                self.image_info_label.setText(f"Image size: {width} x {height} px")
             except:
                 self.image_info_label.setText("Image loaded")
 


### PR DESCRIPTION
Fixed critical bug that prevented plugin from loading on Windows.

Root Cause:
- gcp_generator.py line 64 contained byte 0x92 (Windows-1252 right single quote)
- This caused: "SyntaxError: 'utf-8' codec can't decode byte 0x92"
- Python 3.12 on Windows QGIS could not parse the file

Changes:
- gcp_generator.py: Replaced 0x92 with ASCII arrow (->) in docstring
- main_dialog.py: Replaced Unicode × with ASCII x in image size display

All Python files now use only ASCII characters in code/docstrings (except for print() statements which are safe to use Unicode checkmarks/bullets).

This fixes the error:
  File "gcp_generator.py", line 47
    """Convert match results to QGIS Ground Control Points.
    ^^^
  SyntaxError: (unicode error) 'utf-8' codec can't decode byte 0x92

Verified all .py files now compile successfully with Python 3.12.