### PR TITLE
Add explicit UTF-8 encoding to all file operations

### DIFF
--- a/magic_georeferencer/core/gcp_generator.py
+++ b/magic_georeferencer/core/gcp_generator.py
@@ -244,7 +244,7 @@ class GCPGenerator:
             gcps: List of GCPs
             filepath: Output file path
         """
-        with open(filepath, 'w') as f:
+        with open(filepath, 'w', encoding='utf-8') as f:
             # Write header
             f.write("mapX,mapY,pixelX,pixelY,enable,dX,dY,residual\n")
 
@@ -280,7 +280,7 @@ class GCPGenerator:
         """
         gcps = []
 
-        with open(filepath, 'r') as f:
+        with open(filepath, 'r', encoding='utf-8') as f:
             # Skip header
             next(f)
 

--- a/magic_georeferencer/core/model_manager.py
+++ b/magic_georeferencer/core/model_manager.py
@@ -44,7 +44,7 @@ class ModelManager:
 
         # Load settings
         config_path = Path(__file__).parent.parent / 'config' / 'default_settings.json'
-        with open(config_path, 'r') as f:
+        with open(config_path, 'r', encoding='utf-8') as f:
             self.settings = json.load(f)
 
         self.device = None

--- a/magic_georeferencer/core/tile_fetcher.py
+++ b/magic_georeferencer/core/tile_fetcher.py
@@ -37,7 +37,7 @@ class TileFetcher:
         """Initialize TileFetcher"""
         # Load tile source configurations
         config_path = Path(__file__).parent.parent / 'config' / 'tile_sources.json'
-        with open(config_path, 'r') as f:
+        with open(config_path, 'r', encoding='utf-8') as f:
             self.tile_sources = json.load(f)
 
         # Set up cache directory

--- a/magic_georeferencer/ui/main_dialog.py
+++ b/magic_georeferencer/ui/main_dialog.py
@@ -48,12 +48,12 @@ class MagicGeoreferencerDialog(QDialog):
 
         # Load settings
         config_path = Path(__file__).parent.parent / 'config' / 'default_settings.json'
-        with open(config_path, 'r') as f:
+        with open(config_path, 'r', encoding='utf-8') as f:
             self.settings = json.load(f)
 
         # Load tile sources
         tile_config_path = Path(__file__).parent.parent / 'config' / 'tile_sources.json'
-        with open(tile_config_path, 'r') as f:
+        with open(tile_config_path, 'r', encoding='utf-8') as f:
             self.tile_sources = json.load(f)
 
         # Setup UI


### PR DESCRIPTION
Fix UnicodeDecodeError by adding encoding='utf-8' parameter to all text file open() calls throughout the codebase. This ensures consistent behavior across different system locales and prevents decode errors when files contain special characters like copyright symbols.

Files updated:
- main_dialog.py: JSON config loading
- tile_fetcher.py: Tile sources config loading
- model_manager.py: Settings config loading
- gcp_generator.py: GCP file read/write operations