### PR TITLE
Fix model manager initialization errors

### DIFF
--- a/magic_georeferencer/core/model_manager.py
+++ b/magic_georeferencer/core/model_manager.py
@@ -232,8 +232,8 @@ class ModelManager:
         info = {
             'exists': self.weights_exist(),
             'directory': str(self.weights_dir),
-            'url': self.weights_url,
-            'expected_size_mb': self.settings['model']['weights_size_mb']
+            'repo': self.MODEL_REPO,
+            'expected_size_mb': self.settings['model']['estimated_size_mb']
         }
 
         if info['exists']:

--- a/magic_georeferencer/ui/main_dialog.py
+++ b/magic_georeferencer/ui/main_dialog.py
@@ -231,7 +231,7 @@ class MagicGeoreferencerDialog(QDialog):
 
         text = (
             "Magic Georeferencer uses an AI model to automatically match images.\n\n"
-            f"The model weights (~{self.settings['model']['weights_size_mb']} MB) "
+            f"The model weights (~{self.settings['model']['estimated_size_mb']} MB) "
             "need to be downloaded once.\n\n"
         )
 


### PR DESCRIPTION
- Fixed KeyError for missing 'weights_url' attribute by using MODEL_REPO instead
- Fixed KeyError for 'weights_size_mb' by using correct 'estimated_size_mb' key from config
- Applied fix to both model_manager.py and main_dialog.py

This resolves the "Failed to initialize model manager: 'weights_size_mb'" popup error and ensures the model can be properly loaded for matching operations.