### PR TITLE
Save debug images to diagnose dark tile issue

### DIFF
--- a/magic_georeferencer/core/matcher.py
+++ b/magic_georeferencer/core/matcher.py
@@ -276,6 +276,37 @@ class Matcher:
         print(f"  image_src shape: {image_src.shape}, dtype: {image_src.dtype}, range: [{image_src.min()}, {image_src.max()}]")
         print(f"  image_ref shape: {image_ref.shape}, dtype: {image_ref.dtype}, range: [{image_ref.min()}, {image_ref.max()}]")
 
+        # Debug: Save images to disk for inspection
+        try:
+            from PIL import Image as PILImage
+            from pathlib import Path
+            debug_dir = Path("/tmp/matcher_debug")
+            debug_dir.mkdir(exist_ok=True)
+
+            # Save source image
+            src_pil = PILImage.fromarray(image_src.astype('uint8'))
+            src_path = debug_dir / "source_image.png"
+            src_pil.save(src_path)
+            print(f"  ✓ Saved source image to: {src_path}")
+
+            # Save reference image
+            ref_pil = PILImage.fromarray(image_ref.astype('uint8'))
+            ref_path = debug_dir / "reference_tiles.png"
+            ref_pil.save(ref_path)
+            print(f"  ✓ Saved reference tiles to: {ref_path}")
+
+            # If reference is very dark, try to enhance for inspection
+            if image_ref.max() < 100:
+                print(f"  ⚠ WARNING: Reference image is very dark (max value: {image_ref.max()})")
+                # Save an enhanced version
+                enhanced = (image_ref.astype(float) / image_ref.max() * 255).astype('uint8') if image_ref.max() > 0 else image_ref
+                enhanced_pil = PILImage.fromarray(enhanced)
+                enhanced_path = debug_dir / "reference_tiles_enhanced.png"
+                enhanced_pil.save(enhanced_path)
+                print(f"  ✓ Saved enhanced reference to: {enhanced_path}")
+        except Exception as e:
+            print(f"  ✗ Failed to save debug images: {e}")
+
         # Resize images to target size
         img_src_resized, scale_src = self.model.resize_image(image_src, size)
         img_ref_resized, scale_ref = self.model.resize_image(image_ref, size)


### PR DESCRIPTION
Added code to save source and reference images to /tmp/matcher_debug/ for visual inspection.

When reference image is very dark (max value < 100), also saves an enhanced version with normalized contrast.

This will help diagnose why OSM tiles are coming back nearly black (values only 0-59 instead of 0-255).