### PR TITLE
Add configurable debug output directory to UI

### DIFF
--- a/magic_georeferencer/core/matcher.py
+++ b/magic_georeferencer/core/matcher.py
@@ -67,6 +67,9 @@ class Matcher:
 
         self.model = model_manager.model
 
+        # Debug directory (can be set by UI)
+        self.debug_dir = Path.home() / "georefio_debug"
+
     def match_progressive(
         self,
         image_src: np.ndarray,
@@ -279,9 +282,8 @@ class Matcher:
         # Debug: Save images to disk for inspection
         try:
             from PIL import Image as PILImage
-            from pathlib import Path
-            debug_dir = Path("/tmp/matcher_debug")
-            debug_dir.mkdir(exist_ok=True)
+            debug_dir = self.debug_dir
+            debug_dir.mkdir(parents=True, exist_ok=True)
 
             # Save source image
             src_pil = PILImage.fromarray(image_src.astype('uint8'))


### PR DESCRIPTION
Added UI controls to select debug output directory:
- Text field showing current debug directory (defaults to ~/georefio_debug)
- "Browse..." button to select a custom directory
- "Open Folder" button to open the debug directory in file explorer (works on Windows/macOS/Linux)

Debug images are now saved to the user-selected directory instead of the hardcoded /tmp/matcher_debug path.

This makes it much easier for users to:
1. Choose a convenient location for debug output
2. Find and inspect the saved images
3. Open the folder directly from the plugin

The matcher now uses self.debug_dir which can be set by the UI before running matching.