### PR TITLE
Fix OSM tile access blocked issue

### DIFF
--- a/debug_tile_zoom_coordinates.py
+++ b/debug_tile_zoom_coordinates.py
@@ -269,7 +269,9 @@ def fetch_tiles_at_zoom(extent_3857, zoom, output_path):
             url = tile_url_template.format(z=zoom, x=x, y=y)
 
             try:
-                response = requests.get(url, headers={'User-Agent': 'QGIS Magic Georeferencer'})
+                response = requests.get(url, headers={
+                    'User-Agent': 'MagicGeoreferencer/1.0 (+https://github.com/FungoBungaloid/georefio; QGIS Plugin for AI-powered georeferencing)'
+                })
                 response.raise_for_status()
                 tile_img = Image.open(BytesIO(response.content))
 

--- a/magic_georeferencer/ui/alignment_dialog.py
+++ b/magic_georeferencer/ui/alignment_dialog.py
@@ -160,6 +160,18 @@ class AlignmentDialog(QDialog):
         # Initial map info
         self._update_map_info()
 
+        # Attribution note
+        attribution_label = QLabel(
+            '<p style="color: #666; font-size: 10pt; margin-top: 15px;">'
+            '<b>Note:</b> When using OpenStreetMap tiles, please ensure proper attribution '
+            '(© OpenStreetMap contributors) is included in any published work. '
+            'See <a href="https://www.openstreetmap.org/copyright">osmorg/copyright</a> for details.'
+            '</p>'
+        )
+        attribution_label.setWordWrap(True)
+        attribution_label.setOpenExternalLinks(True)
+        layout.addWidget(attribution_label)
+
         # Buttons
         button_layout = QHBoxLayout()
 


### PR DESCRIPTION
OSM was blocking tile requests because we were using the default python-requests User-Agent, which violates their tile usage policy.

Changes:
- Add proper User-Agent header identifying the app with contact info
- Implement HTTP caching with 7-day minimum TTL (per OSM policy)
- Add conditional request support (If-None-Match, If-Modified-Since)
- Use requests.Session for connection pooling and efficiency
- Add OSM attribution note to UI
- Update debug script with correct User-Agent

This complies with OSM tile usage policy at:
https://operations.osmfoundation.org/policies/tiles/

Fixes the "access blocked" tiles that were being returned.