### PR TITLE
Fix workflow bugs and add OSM cache management

### DIFF
--- a/clear_osm_cache.py
+++ b/clear_osm_cache.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""
+Utility script to clear the Magic Georeferencer tile cache.
+
+This is useful if you have cached "access blocked" tiles from OSM
+before the User-Agent fix was applied.
+
+Run this from the QGIS Python console:
+    exec(open('/home/user/georefio/clear_osm_cache.py').read())
+"""
+
+from pathlib import Path
+from qgis.core import QgsApplication
+
+# Get cache directory
+cache_base = Path(QgsApplication.qgisSettingsDirPath())
+cache_dir = cache_base / 'magic_georeferencer' / 'tiles'
+
+if not cache_dir.exists():
+    print(f"Cache directory does not exist: {cache_dir}")
+    print("No cached tiles to clear.")
+else:
+    # Count files
+    png_files = list(cache_dir.glob("*.png"))
+    meta_files = list(cache_dir.glob("*.meta"))
+
+    print(f"Found {len(png_files)} cached tile images")
+    print(f"Found {len(meta_files)} cached metadata files")
+
+    if png_files or meta_files:
+        response = input(f"\nDelete {len(png_files) + len(meta_files)} cached files? (y/n): ")
+
+        if response.lower() == 'y':
+            # Delete all cache files
+            for f in png_files:
+                f.unlink()
+            for f in meta_files:
+                f.unlink()
+
+            print(f"\n✓ Cleared {len(png_files) + len(meta_files)} cached files")
+            print("Next tile fetch will use fresh tiles with proper User-Agent.")
+        else:
+            print("\nCache clearing cancelled.")
+    else:
+        print("\nNo cached files found.")
+
+print(f"\nCache directory: {cache_dir}")

--- a/magic_georeferencer/ui/main_dialog.py
+++ b/magic_georeferencer/ui/main_dialog.py
@@ -612,7 +612,7 @@ class MagicGeoreferencerDialog(QDialog):
                 self.source_image_path,
                 gcps,
                 output_path,
-                crs,
+                web_mercator_crs,  # Use the CRS we defined earlier
                 transform_type=transform_type,
                 resampling=self.settings['georeferencing']['default_resampling'],
                 compression=self.settings['georeferencing']['default_compression']


### PR DESCRIPTION
Two critical fixes:

1. Fix undefined CRS variable bug in main_dialog.py
   - Line 615 referenced undefined 'crs' variable
   - Changed to use 'web_mercator_crs' defined earlier
   - This was preventing georeferencing from completing

2. Add OSM cache management and rate limiting
   - Old "access blocked" tiles were cached before User-Agent fix
   - Added clear_cache() method to TileFetcher
   - Added rate limiting (50ms between requests, max 20/sec)
   - Created clear_osm_cache.py utility script

The georeferencing workflow was already complete - it calls Georeferencer.georeference_image() which uses gdalwarp and automatically loads the result into QGIS via load_raster().

With these fixes:
- Georeferenced images should now appear in QGIS automatically
- OSM tiles can be re-fetched with proper User-Agent after cache clear
- Respectful rate limiting prevents server overload