### PR TITLE
Fix Windows symlink error and add initialization loading indicator

### DIFF
--- a/magic_georeferencer/ui/main_dialog.py
+++ b/magic_georeferencer/ui/main_dialog.py
@@ -61,8 +61,16 @@ class MagicGeoreferencerDialog(QDialog):
         self.setMinimumWidth(600)
         self._setup_ui()
 
-        # Initialize model manager
-        self._init_model_manager()
+        # Initialize model manager with loading indicator
+        # This can take 5-10 seconds on first run
+        from qgis.PyQt.QtCore import QTimer, QCoreApplication
+
+        # Show status message
+        self.status_label.setText("Initializing AI model...")
+        QCoreApplication.processEvents()  # Update UI
+
+        # Use QTimer to let UI update before heavy operation
+        QTimer.singleShot(100, self._init_model_manager)
 
     def _setup_ui(self):
         """Setup user interface"""
@@ -234,9 +242,13 @@ class MagicGeoreferencerDialog(QDialog):
             self.model_manager = ModelManager()
 
             if self.model_manager.check_first_run():
+                self.status_label.setText("Ready - Model weights need to be downloaded")
                 self._show_first_run_dialog()
+            else:
+                self.status_label.setText("Ready")
 
         except Exception as e:
+            self.status_label.setText("Error during initialization")
             QMessageBox.critical(
                 self,
                 "Initialization Error",


### PR DESCRIPTION
Two critical improvements:

1. Fix Windows Permission Error ([WinError 1314])
   - HuggingFace tries to create symlinks by default
   - Symlinks require admin privileges on Windows
   - Solution: Set HF_HUB_DISABLE_SYMLINKS_WARNING environment variable
   - Use AutoModel.from_pretrained() which handles this better
   - Added Windows detection and informative messages
   - Simplified download to avoid snapshot_download issues

2. Add Loading Indicator During Plugin Initialization
   - Shows "Initializing AI model..." status during startup
   - Uses QTimer.singleShot to allow UI to update first
   - Clears to "Ready" when initialization complete
   - Prevents 5-10 second freeze with no feedback
   - Much better UX - user knows something is happening

Technical Details:
- model_manager.py: Removed snapshot_download, using AutoModel only
- model_manager.py: Added OS detection and symlink warnings
- model_manager.py: Better progress callbacks during download
- main_dialog.py: QTimer for async initialization
- main_dialog.py: Status label updates throughout init process

This should fix the Windows download issue completely.