### PR TITLE
Fix plugin loading delay and 'model not loaded' error

### DIFF
--- a/magic_georeferencer/magic_georeferencer.py
+++ b/magic_georeferencer/magic_georeferencer.py
@@ -42,6 +42,10 @@ class MagicGeoreferencer:
         # Plugin dialog
         self.dialog = None
 
+        # Cache dependency check result to avoid repeated checks
+        self._dependencies_checked = False
+        self._dependencies_available = False
+
     def tr(self, message):
         """Get the translation for a string using Qt translation API."""
         return QCoreApplication.translate('MagicGeoreferencer', message)
@@ -129,10 +133,13 @@ class MagicGeoreferencer:
 
     def run(self):
         """Run method that performs all the real work"""
-        # Check dependencies before importing
-        from .dependency_installer import check_and_prompt_install
+        # Check dependencies before importing (cache result to avoid repeated checks)
+        if not self._dependencies_checked:
+            from .dependency_installer import check_and_prompt_install
+            self._dependencies_available = check_and_prompt_install(self.iface.mainWindow())
+            self._dependencies_checked = True
 
-        if not check_and_prompt_install(self.iface.mainWindow()):
+        if not self._dependencies_available:
             # Dependencies not available or user cancelled
             return
 

--- a/magic_georeferencer/ui/main_dialog.py
+++ b/magic_georeferencer/ui/main_dialog.py
@@ -72,6 +72,17 @@ class MagicGeoreferencerDialog(QDialog):
         # Use QTimer to let UI update before heavy operation
         QTimer.singleShot(100, self._init_model_manager)
 
+    def showEvent(self, event):
+        """Override showEvent to ensure model is initialized when dialog is shown"""
+        super().showEvent(event)
+
+        # Check if model manager needs to be initialized (e.g., after QGIS restart)
+        if self.model_manager is None:
+            from qgis.PyQt.QtCore import QTimer, QCoreApplication
+            self.status_label.setText("Initializing AI model...")
+            QCoreApplication.processEvents()
+            QTimer.singleShot(100, self._init_model_manager)
+
     def _setup_ui(self):
         """Setup user interface"""
         layout = QVBoxLayout()
@@ -240,7 +251,9 @@ class MagicGeoreferencerDialog(QDialog):
                 self.status_label.setText("Ready - Model weights need to be downloaded")
                 self._show_first_run_dialog()
             else:
-                self.status_label.setText("Ready")
+                # Weights exist - load the model automatically
+                self.status_label.setText("Loading model...")
+                self._load_model()
 
         except Exception as e:
             self.status_label.setText("Error during initialization")


### PR DESCRIPTION
This commit fixes three critical issues that caused the plugin to fail after QGIS restart:

1. Model not loading when weights exist:
   - Previously, when model weights already existed, _init_model_manager() would just set status to "Ready" without actually loading the model into memory
   - Now automatically calls _load_model() when weights exist
   - File: magic_georeferencer/ui/main_dialog.py:245-256

2. Model state lost when dialog is reused:
   - Added showEvent() override to check if model_manager is None and reinitialize
   - This handles cases where dialog persists but model manager is lost (e.g., after QGIS restart)
   - File: magic_georeferencer/ui/main_dialog.py:75-84

3. Dependency check delay on every plugin click:
   - Added caching for dependency check results to avoid repeated 1-2 second delays
   - Now only checks dependencies once per QGIS session
   - File: magic_georeferencer/magic_georeferencer.py:45-47, 136-144

These changes ensure the model is properly loaded whether it's the first run or a subsequent session, and significantly reduce the delay when opening the plugin.