### PR TITLE
Fix batch georeferencing: clean up broken code and add enhancements

### DIFF
--- a/magic_georeferencer/core/batch_processor.py
+++ b/magic_georeferencer/core/batch_processor.py
@@ -91,7 +91,6 @@ class BatchConfig:
     auto_quality: bool = True  # Use progressive quality backoff
 
     # Manual matching settings (used when auto modes are disabled)
-    # Matching settings
     basemap_source: str = "osm_standard"
     quality_preset: str = "balanced"
     confidence_threshold: float = 0.70
@@ -325,17 +324,6 @@ class BatchProcessor:
             self.log("Progressive quality backoff: ENABLED (strict -> balanced -> permissive -> very_permissive)")
         else:
             self.log(f"Progressive quality backoff: DISABLED (using {config.quality_preset})")
-        # Get confidence threshold from quality preset
-        confidence_thresholds = {
-            'strict': 0.85,
-            'balanced': 0.70,
-            'permissive': 0.55,
-            'very_permissive': 0.20
-        }
-        confidence_threshold = confidence_thresholds.get(
-            config.quality_preset,
-            config.confidence_threshold
-        )
 
         # Process each image
         for i, image_path in enumerate(image_paths):
@@ -367,7 +355,6 @@ class BatchProcessor:
                 config=config,
                 vision_client=vision_client,
                 target_crs=target_crs,
-                confidence_threshold=confidence_threshold,
                 progress=progress
             )
 
@@ -404,18 +391,12 @@ class BatchProcessor:
     ) -> BatchItemResult:
         """
         Process a single image with automatic basemap selection and progressive quality backoff.
-        confidence_threshold: float,
-        progress: BatchProgress
-    ) -> BatchItemResult:
-        """
-        Process a single image.
 
         Args:
             image_path: Path to image
             config: Batch configuration
             vision_client: Vision API client
             target_crs: Target CRS for output
-            confidence_threshold: Confidence threshold for matching
             progress: Progress object for updates
 
         Returns:
@@ -459,8 +440,6 @@ class BatchProcessor:
                 basemap_source = config.basemap_source
                 self.log(f"    Using manual basemap: {basemap_source}")
 
-            self.log(f"    Reasoning: {bbox.reasoning[:100]}...")
-
             # Step 2: Load and prepare source image
             progress.current_step = "Loading source image..."
             self.update_progress(progress)
@@ -477,13 +456,6 @@ class BatchProcessor:
             # Calculate aspect ratio
             src_height, src_width = source_image.shape[:2]
             source_aspect_ratio = src_width / src_height
-
-            # Step 3: Fetch reference tiles
-            progress.current_step = "Fetching reference tiles..."
-            self.update_progress(progress)
-            result.status = BatchItemStatus.FETCHING_TILES
-
-            self.log(f"  Step 3: Fetching reference tiles...")
 
             # Calculate extent in meters and optimal zoom
             extent_meters = bbox.to_extent_meters()
@@ -564,40 +536,6 @@ class BatchProcessor:
                 raise ValueError(
                     f"Could not find sufficient matches at any quality level "
                     f"(minimum {config.min_gcps} required)"
-            self.log(f"    Extent: {extent_meters:.0f}m, Base zoom: {base_zoom}")
-
-            # Step 4: Run multi-zoom matching
-            progress.current_step = "Matching images..."
-            self.update_progress(progress)
-            result.status = BatchItemStatus.MATCHING
-
-            self.log(f"  Step 4: Running image matching...")
-
-            match_result, ref_image, ref_extent, best_zoom = self.matcher.match_multi_zoom(
-                image_src=source_image,
-                center_lat=bbox.center_lat,
-                center_lon=bbox.center_lon,
-                extent_meters=extent_meters,
-                extent_dimension='horizontal',  # Use horizontal as default
-                tile_fetcher=self.tile_fetcher,
-                basemap_source=config.basemap_source,
-                base_zoom=base_zoom,
-                zoom_range=config.zoom_range
-            )
-
-            # Filter matches by confidence
-            match_result = self.matcher.filter_matches(
-                match_result,
-                confidence_threshold=confidence_threshold,
-                min_gcps=config.min_gcps
-            )
-
-            num_matches = match_result.num_matches()
-            self.log(f"    Found {num_matches} matches (confidence >= {confidence_threshold})")
-
-            if num_matches < config.min_gcps:
-                raise ValueError(
-                    f"Insufficient matches: {num_matches} (minimum {config.min_gcps} required)"
                 )
 
             # Store match metrics
@@ -675,17 +613,6 @@ class BatchProcessor:
             finally:
                 # Restore original iface
                 self.georeferencer.iface = original_iface
-            # Run georeferencing
-            success, message = self.georeferencer.georeference_image(
-                source_image_path=image_path,
-                gcps=gcps,
-                output_path=output_path,
-                target_crs=target_crs,
-                transform_type=transform_type,
-                resampling=config.resampling,
-                compression=config.compression,
-                progress_callback=None  # Don't use nested progress
-            )
 
             if not success:
                 raise RuntimeError(f"Georeferencing failed: {message}")
@@ -695,7 +622,6 @@ class BatchProcessor:
             result.processing_time = time.time() - item_start_time
 
             self.log(f"  ✓ Completed in {result.processing_time:.1f}s (basemap: {basemap_source}, quality: {successful_preset})")
-            self.log(f"  ✓ Completed in {result.processing_time:.1f}s")
 
         except Exception as e:
             result.status = BatchItemStatus.FAILED

--- a/magic_georeferencer/core/vision_api.py
+++ b/magic_georeferencer/core/vision_api.py
@@ -163,42 +163,45 @@ class BoundingBoxEstimate:
 
 
 # System prompt for geographic analysis
-VISION_SYSTEM_PROMPT = """You are a geographic analysis expert. Your task is to analyze images (maps, aerial photos, sketches, historical documents) and estimate their geographic location, and recommend the best reference basemap for matching."""
-
-Analyze the image for geographic clues including:
-- Text labels (city names, street names, landmarks, region names)
-- Coastlines, rivers, lakes, and other water bodies
-- Street patterns and road networks
-- Distinctive landmarks (mountains, buildings, monuments)
-- Cartographic style and era indicators
-- Scale indicators or distance markers
-- Compass roses or north arrows
-- Administrative boundaries
-
-Based on your analysis, provide a bounding box estimate in WGS84 coordinates (EPSG:4326) and recommend the best basemap for feature matching.
-
-IMPORTANT: You MUST respond with ONLY valid JSON in this exact format, with no additional text before or after:
-{"min_lon": <number>, "min_lat": <number>, "max_lon": <number>, "max_lat": <number>, "recommended_basemap": "<basemap_key>", "reasoning": "<explanation>"}
-
-Basemap options (choose the key that best matches your image type):
-- "osm_standard": OpenStreetMap Standard - best for road maps, city maps, street plans, maps with labeled features, urban areas
-- "esri_world_imagery": ESRI World Imagery - best for aerial photographs, satellite imagery, natural landscapes, rural areas, terrain features
-- "osm_humanitarian": OpenStreetMap Humanitarian - best for high-contrast needs, simplified features, historical maps with faded colors, developing regions
-Based on your analysis, provide a bounding box estimate in WGS84 coordinates (EPSG:4326).
-
-IMPORTANT: You MUST respond with ONLY valid JSON in this exact format, with no additional text before or after:
-{"min_lon": <number>, "min_lat": <number>, "max_lon": <number>, "max_lat": <number>, "reasoning": "<explanation>"}
-
-Guidelines:
-- Be conservative with the bounding box - it's better to be slightly larger than to miss the area
-- If you can identify a specific city or region, the bounding box should cover that area
-- For maps with clear boundaries shown, estimate based on those boundaries
-- If uncertain, provide a larger regional bounding box and explain in reasoning
-- min_lon/max_lon: West/East bounds (-180 to 180)
-- min_lat/max_lat: South/North bounds (-90 to 90)
-- Choose osm_standard for maps/drawings, esri_world_imagery for photos, osm_humanitarian for old/faded documents
-- Reasoning should be concise (1-2 sentences) explaining key identifying features and basemap choice"""
-- Reasoning should be concise (1-2 sentences) explaining key identifying features"""
+VISION_SYSTEM_PROMPT = (
+    "You are a geographic analysis expert. Your task is to analyze images "
+    "(maps, aerial photos, sketches, historical documents) and estimate their "
+    "geographic location, and recommend the best reference basemap for matching.\n\n"
+    "Analyze the image for geographic clues including:\n"
+    "- Text labels (city names, street names, landmarks, region names)\n"
+    "- Coastlines, rivers, lakes, and other water bodies\n"
+    "- Street patterns and road networks\n"
+    "- Distinctive landmarks (mountains, buildings, monuments)\n"
+    "- Cartographic style and era indicators\n"
+    "- Scale indicators or distance markers\n"
+    "- Compass roses or north arrows\n"
+    "- Administrative boundaries\n\n"
+    "Based on your analysis, provide a bounding box estimate in WGS84 coordinates "
+    "(EPSG:4326) and recommend the best basemap for feature matching.\n\n"
+    "IMPORTANT: You MUST respond with ONLY valid JSON in this exact format, "
+    "with no additional text before or after:\n"
+    '{"min_lon": <number>, "min_lat": <number>, "max_lon": <number>, '
+    '"max_lat": <number>, "recommended_basemap": "<basemap_key>", '
+    '"reasoning": "<explanation>"}\n\n'
+    "Basemap options (choose the key that best matches your image type):\n"
+    '- "osm_standard": OpenStreetMap Standard - best for road maps, city maps, '
+    "street plans, maps with labeled features, urban areas\n"
+    '- "esri_world_imagery": ESRI World Imagery - best for aerial photographs, '
+    "satellite imagery, natural landscapes, rural areas, terrain features\n"
+    '- "osm_humanitarian": OpenStreetMap Humanitarian - best for high-contrast '
+    "needs, simplified features, historical maps with faded colors, developing regions\n\n"
+    "Guidelines:\n"
+    "- Be conservative with the bounding box. A slightly larger box is better than missing the area\n"
+    "- If you can identify a specific city or region, the bounding box should cover that area\n"
+    "- For maps with clear boundaries shown, estimate based on those boundaries\n"
+    "- If uncertain, provide a larger regional bounding box and explain in reasoning\n"
+    "- min_lon/max_lon: West/East bounds (-180 to 180)\n"
+    "- min_lat/max_lat: South/North bounds (-90 to 90)\n"
+    "- Choose osm_standard for maps/drawings, esri_world_imagery for photos, "
+    "osm_humanitarian for old/faded documents\n"
+    "- Reasoning should be concise (1-2 sentences) explaining key identifying "
+    "features and basemap choice"
+)
 
 
 class VisionAPIClient:

--- a/magic_georeferencer/ui/batch_dialog.py
+++ b/magic_georeferencer/ui/batch_dialog.py
@@ -295,9 +295,6 @@ class BatchDialog(QDialog):
         self.quality_label = QLabel("Quality:")
         quality_layout = QHBoxLayout()
         quality_layout.addWidget(self.quality_label)
-        # Match quality
-        quality_layout = QHBoxLayout()
-        quality_layout.addWidget(QLabel("Quality:"))
 
         self.quality_combo = QComboBox()
         self.quality_combo.addItem("Strict (0.85)", "strict")
@@ -334,9 +331,6 @@ class BatchDialog(QDialog):
         # Show/hide automatic mode indicators
         self.auto_basemap_label.setVisible(not manual_mode)
         self.auto_quality_label.setVisible(not manual_mode)
-
-        group.setLayout(layout)
-        return group
 
     def _create_output_group(self) -> QGroupBox:
         """Create output configuration group."""
@@ -718,8 +712,6 @@ class BatchDialog(QDialog):
             quality_preset=self.quality_combo.currentData(),
             # Never auto-load results in batch mode
             auto_load_result=False,
-            basemap_source=self.basemap_combo.currentData(),
-            quality_preset=self.quality_combo.currentData(),
         )
 
         # Update UI for processing state
@@ -823,11 +815,6 @@ class BatchDialog(QDialog):
             self.basemap_label.setEnabled(False)
             self.quality_combo.setEnabled(False)
             self.quality_label.setEnabled(False)
-
-        self.basemap_combo.setEnabled(not processing)
-        self.quality_combo.setEnabled(not processing)
-        self.output_dir_edit.setEnabled(not processing)
-        self.suffix_edit.setEnabled(not processing)
 
         # Toggle buttons
         self.start_btn.setVisible(not processing)


### PR DESCRIPTION
This commit fixes corrupted code from previous merge conflicts and adds:

- Fixed VISION_SYSTEM_PROMPT string syntax (was causing SyntaxError)
- Automatic basemap selection: vision AI recommends best basemap per image
- Progressive quality backoff: tries strict -> balanced -> permissive -> very_permissive
- Manual override option with "Enable manual control" checkbox
- Disabled auto-load of georeferenced images to map canvas

The batch georeferencing feature now works fully automatically by default, selecting the optimal basemap and match quality settings for each image.