### PR TITLE
Fix OpenAI API error: use max_completion_tokens parameter

### DIFF
--- a/magic_georeferencer/core/vision_api.py
+++ b/magic_georeferencer/core/vision_api.py
@@ -356,7 +356,7 @@ class VisionAPIClient:
                     ]
                 }
             ],
-            "max_tokens": 500,
+            "max_completion_tokens": 500,
             "temperature": 0.1  # Low temperature for more consistent output
         }
 


### PR DESCRIPTION
Newer OpenAI models require 'max_completion_tokens' instead of 'max_tokens'. This was causing batch processing to fail with a 400 error for all images when using OpenAI models.